### PR TITLE
API / Extent / Allow to request only one geometry

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
+++ b/core/src/main/java/org/fao/geonet/kernel/security/ldap/README.md
@@ -3,7 +3,9 @@ Using LDAPUserDetailsContextMapperWithProfileSearchEnhanced
 
 `LDAPUserDetailsContextMapperWithProfileSearch` was modified so it works in more situations, is much simpler, uses strategy objects, and has a good set of test cases.
 
-The original `LDAPUserDetailsContextMapperWithProfileSearch` was extremely difficult to understand.
+This extends the original `LDAPUserDetailsContextMapperWithProfileSearch` so it can support more LDAP configurations.
+
+The old `LDAPUserDetailsContextMapperWithProfileSearch` should work as before - existing configurations should not need any changes.
 
 Please see the test cases (and the corresponding README.md).  This contains;
 

--- a/services/src/main/java/org/fao/geonet/api/records/extent/ExtentDto.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/ExtentDto.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.records.extent;
+
+public class ExtentDto {
+    public ExtentDto() {}
+    public ExtentDto(String href, String type, String xpath, String description) {
+        this.href = href;
+        this.type = type;
+        this.xpath = xpath;
+        this.description = description;
+    }
+
+    private String href;
+    private String type;
+    private String xpath;
+    private String description;
+
+    public String getHref() {
+        return href;
+    }
+
+    public void setHref(String href) {
+        this.href = href;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public void setXpath(String xpath) {
+        this.xpath = xpath;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -33,17 +33,20 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.regions.MetadataRegionDAO;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.region.Request;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.utils.XPath;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
 import springfox.documentation.annotations.ApiIgnore;
 
@@ -51,6 +54,10 @@ import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
@@ -81,56 +88,179 @@ public class MetadataExtentApi {
     public static final String WIDTH_AND_HEIGHT_BOTH_MISSING_MESSAGE =
         String.format("One of $s or $s parameters must be included in the request", WIDTH_PARAM, HEIGHT_PARAM);
 
+    private static final String API_EXTENT_DESCRIPTION = "A rendering of the geometry as a png. If no background is specified the image will be " +
+        "transparent. In getMap the envelope of the geometry is calculated then it is expanded by a " +
+        "factor.  That factor is the size of the map.  This allows the map to be slightly bigger than " +
+        "the geometry allowing some context to be shown. This parameter allows different factors to be " +
+        "chosen per scale level." +
+        "\n" +
+        "Proportion is the proportion of the world that the geometry covers (bounds of WGS84)/(bounds " +
+        "of geometry in WGS84)\n" +
+        "\n" +
+        "Named backgrounds allow the background parameter to be a simple key and the complete URL will " +
+        "be looked up from this list of named backgrounds\n";
+
+    private static final String API_PARAM_WIDTH_DESCRIPTION = "(optional) width of the image that is created. Only one of width and height are permitted";
+    private static final String API_PARAM_HEIGHT_DESCRIPTION = "(optional) height of the image that is created. Only one of width and height are permitted";
+    private static final String API_PARAM_BG_DESCRIPTION = "(optional) URL for loading a background image for regions or a key that references the namedBackgrounds (configured in config-spring-geonetwork.xml). A WMS Getmap request is the typical example. The URL must be parameterized with the following parameters: minx, maxx, miny, maxy, width, height";
+    private static final String API_PARAM_FILL_DESCRIPTION = "(optional) Fill color with format RED,GREEN,BLUE,ALPHA";
+    private static final String API_PARAM_STROKE_DESCRIPTION = "(optional) Stroke color with format RED,GREEN,BLUE,ALPHA";
+
+    private static final String EXTENT_XPATH = ".//*[local-name() ='extent']/*/*[local-name() = 'geographicElement']/*";
+    private static final String EXTENT_DESCRIPTION_XPATH = "ancestor::*[local-name() = 'EX_Extent']/*[local-name() = 'description']/*/text()";
+
     @Autowired
     private MetadataRegionDAO metadataRegionDAO;
 
+    @Autowired
+    SchemaManager schemaManager;
+
+    @Autowired
+    SettingManager settingManager;
+
     @ApiOperation(
-        value = "Get record extents as image",
-        notes = "A rendering of the geometry as a png. If no background is specified the image will be " +
-            "transparent. In getMap the envelope of the geometry is calculated then it is expanded by a " +
-            "factor.  That factor is the size of the map.  This allows the map to be slightly bigger than " +
-            "the geometry allowing some context to be shown. This parameter allows different factors to be " +
-            "chosen per scale level." +
-            "\n" +
-            "Proportion is the proportion of the world that the geometry covers (bounds of WGS84)/(bounds " +
-            "of geometry in WGS84)\n" +
-            "\n" +
-            "Named backgrounds allow the background parameter to be a simple key and the complete URL will " +
-            "be looked up from this list of named backgrounds\n",
-        nickname = "getRecordExtents")
+        value = "Get all record extents as image",
+        notes = API_EXTENT_DESCRIPTION,
+        nickname = "getAllRecordExtents")
     @RequestMapping(
         value = "/{metadataUuid}/extents.png",
         produces = {
             MediaType.IMAGE_PNG_VALUE
         },
         method = RequestMethod.GET)
-    public HttpEntity<byte[]> getRecordExtentAsImage(
+    public HttpEntity<byte[]> getAllRecordExtentAsImage(
         @ApiParam(
             value = API_PARAM_RECORD_UUID,
             required = true)
         @PathVariable(value = "metadataUuid")
             String metadataUuid,
         @RequestParam(value = MAP_SRS_PARAM, defaultValue = "EPSG:4326") String srs,
-        @ApiParam(value = "(optional) width of the image that is created. Only one of width and height are permitted")
+        @ApiParam(value = API_PARAM_WIDTH_DESCRIPTION)
         @RequestParam(value = WIDTH_PARAM, required = false, defaultValue = "300") Integer width,
-        @ApiParam(value = "(optional) height of the image that is created. Only one of width and height are permitted")
+        @ApiParam(value = API_PARAM_HEIGHT_DESCRIPTION)
         @RequestParam(value = HEIGHT_PARAM, required = false) Integer height,
-        @ApiParam(value = "(optional) URL for loading a background image for regions or a key that references the namedBackgrounds (configured in config-spring-geonetwork.xml). A WMS Getmap request is the typical example. The URL must be parameterized with the following parameters: minx, maxx, miny, maxy, width, height")
+        @ApiParam(value = API_PARAM_BG_DESCRIPTION)
         @RequestParam(value = BACKGROUND_PARAM, required = false, defaultValue = "settings") String background,
-        @ApiParam(value = "(optional) Fill color with format RED,GREEN,BLUE,ALPHA")
+        @ApiParam(value = API_PARAM_FILL_DESCRIPTION)
         @RequestParam(value = "", required = false, defaultValue = "0,0,0,50")
         String fillColor,
-        @ApiParam(value = "(optional) Stroke color with format RED,GREEN,BLUE,ALPHA")
+        @ApiParam(value = API_PARAM_STROKE_DESCRIPTION)
         @RequestParam(value = "", required = false, defaultValue = "0,0,0,255")
         String strokeColor,
-        @ApiParam(value = "(optional) restrict display to one extent given its order of appearence")
-        @RequestParam(value = "", required = false)
-        Integer extentOrderOfAppearence,
         @ApiIgnore
             NativeWebRequest nativeWebRequest,
         @ApiIgnore
             HttpServletRequest request) throws Exception {
 
+        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, null, nativeWebRequest, request);
+    }
+
+
+
+    @ApiOperation(
+        value = "Get list of record extents",
+        notes = API_EXTENT_DESCRIPTION,
+        nickname = "getAllRecordExtentsAsJson")
+    @RequestMapping(
+        value = "/{metadataUuid}/extents.json",
+        produces = {
+            MediaType.APPLICATION_JSON_VALUE
+        },
+        method = RequestMethod.GET)
+    @ResponseBody
+    public List<ExtentDto> getAllRecordExtentAsJson(
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable(value = "metadataUuid")
+            String metadataUuid,
+        @ApiIgnore
+            NativeWebRequest nativeWebRequest,
+        @ApiIgnore
+            HttpServletRequest request) throws Exception {
+        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+        ServiceContext context = ApiUtils.createServiceContext(request);
+
+        MetadataSchema schema = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
+
+        Element xmlData = metadata.getXmlData(false);
+        List<?> extentList = Xml.selectNodes(
+            xmlData,
+            EXTENT_XPATH, schema.getNamespaces());
+
+        List<ExtentDto> response = new ArrayList<>(extentList.size() + 1);
+        response.add(new ExtentDto(
+            String.format("%sapi/records/%s/extents.png",
+                settingManager.getNodeURL(), metadataUuid),
+            "ALL",
+            "",
+            ""));
+
+        int index = 1;
+
+        for (Object extent : extentList) {
+            if (extent instanceof Element) {
+                Element extentElement = (Element) extent;
+
+                String description =
+                    Xml.selectString(extentElement,
+                        EXTENT_DESCRIPTION_XPATH,
+                        schema.getNamespaces());
+
+                response.add(new ExtentDto(
+                    String.format("%sapi/records/%s/extents/%d.png",
+                        settingManager.getNodeURL(), metadataUuid, index),
+                    extentElement.getName(),
+                    XPath.getXPath(xmlData, (Element) extent),
+                    description));
+                index ++;
+            }
+        }
+        return response;
+    }
+
+
+    @ApiOperation(
+        value = "Get one record extent as image",
+        notes = API_EXTENT_DESCRIPTION,
+        nickname = "getOneRecordExtent")
+    @RequestMapping(
+        value = "/{metadataUuid}/extents/{geometryIndex}.png",
+        produces = {
+            MediaType.IMAGE_PNG_VALUE
+        },
+        method = RequestMethod.GET)
+    public HttpEntity<byte[]> getOneRecordExtentAsImage(
+        @ApiParam(
+            value = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable(value = "metadataUuid")
+            String metadataUuid,
+        @ApiParam(value = "Index of the geometry or bounding box to display. Starts at 1.")
+        @PathVariable(value = "geometryIndex")
+            Integer geometryIndex,
+        @RequestParam(value = MAP_SRS_PARAM, defaultValue = "EPSG:4326") String srs,
+        @ApiParam(value = API_PARAM_WIDTH_DESCRIPTION)
+        @RequestParam(value = WIDTH_PARAM, required = false, defaultValue = "300") Integer width,
+        @ApiParam(value = API_PARAM_HEIGHT_DESCRIPTION)
+        @RequestParam(value = HEIGHT_PARAM, required = false) Integer height,
+        @ApiParam(value = API_PARAM_BG_DESCRIPTION)
+        @RequestParam(value = BACKGROUND_PARAM, required = false, defaultValue = "settings") String background,
+        @ApiParam(value = API_PARAM_FILL_DESCRIPTION)
+        @RequestParam(value = "", required = false, defaultValue = "0,0,0,50")
+            String fillColor,
+        @ApiParam(value = API_PARAM_STROKE_DESCRIPTION)
+        @RequestParam(value = "", required = false, defaultValue = "0,0,0,255")
+            String strokeColor,
+        @ApiIgnore
+            NativeWebRequest nativeWebRequest,
+        @ApiIgnore
+            HttpServletRequest request) throws Exception {
+
+        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, geometryIndex, nativeWebRequest, request);
+    }
+
+    private HttpEntity<byte[]> getExtent(String metadataUuid, String srs, Integer width, Integer height, String background, String fillColor, String strokeColor, Integer extentOrderOfAppearence, NativeWebRequest nativeWebRequest, HttpServletRequest request) throws Exception {
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
@@ -147,8 +277,9 @@ public class MetadataExtentApi {
             regionId = String.format("metadata:@id%s", metadata.getId());
         } else {
             regionId = String.format(
-                "metadata:@id%s:@xpath*//gmd:extent[%d]//*/gmd:EX_BoundingPolygon | *//gmd:extent[%d][not(descendant::*[name() = 'gmd:EX_BoundingPolygon'])]//*/gmd:EX_GeographicBoundingBox",
-                metadata.getId(), extentOrderOfAppearence, extentOrderOfAppearence);
+                "metadata:@id%s:" +
+                    "@xpath(%s)[%d]",
+                metadata.getId(), EXTENT_XPATH, extentOrderOfAppearence);
         }
 
         Request searchRequest = metadataRegionDAO.createSearchRequest(context).id(regionId);

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -181,7 +181,8 @@ public class MetadataExtentApi {
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
-        MetadataSchema schema = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
+        String schemaId = metadata.getDataInfo().getSchemaId();
+        MetadataSchema schema = schemaManager.getSchema(schemaId);
 
         Element xmlData = metadata.getXmlData(false);
         List<?> extentList = Xml.selectNodes(
@@ -189,12 +190,14 @@ public class MetadataExtentApi {
             EXTENT_XPATH, schema.getNamespaces());
 
         List<ExtentDto> response = new ArrayList<>(extentList.size() + 1);
-        response.add(new ExtentDto(
-            String.format("%sapi/records/%s/extents.png",
-                settingManager.getNodeURL(), metadataUuid),
-            "ALL",
-            "",
-            ""));
+        if (!"iso19110".equals(schemaId)) {
+            response.add(new ExtentDto(
+                String.format("%sapi/records/%s/extents.png",
+                    settingManager.getNodeURL(), metadataUuid),
+                "ALL",
+                "",
+                ""));
+        }
 
         int index = 1;
 

--- a/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/MetadataRegion.java
@@ -43,12 +43,14 @@ public class MetadataRegion extends Region {
     public MetadataRegion(Id mdId, String id, Geometry geometry) {
         super("metadata" + mdId.getIdentifiedId() + ":" + id, Collections.<String, String>emptyMap(), MetadataRegionDAO.CATEGORY_NAME,
             Collections.<String, String>emptyMap(), true,
-            new ReferencedEnvelope(geometry.getEnvelopeInternal(), WGS84));
+            geometry != null ? new ReferencedEnvelope(geometry.getEnvelopeInternal(), WGS84) : null);
         this.geometry = geometry;
     }
 
     public Geometry getGeometry(CoordinateReferenceSystem projection) throws Exception {
-
+        if (geometry == null) {
+            return null;
+        }
         CoordinateReferenceSystem coordinateReferenceSystem = getBBox().getCoordinateReferenceSystem();
         Integer sourceCode = CRS.lookupEpsgCode(coordinateReferenceSystem, false);
         Integer desiredCode = CRS.lookupEpsgCode(projection, false);

--- a/services/src/test/resources/org/fao/geonet/api/records/extent/metadata.iso19115-3_with_three_extent.xml
+++ b/services/src/test/resources/org/fao/geonet/api/records/extent/metadata.iso19115-3_with_three_extent.xml
@@ -1,0 +1,420 @@
+<mdb:MD_Metadata xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0"
+                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+                 xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
+                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0"
+                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                 xmlns:gml="http://www.opengis.net/gml/3.2"
+                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0">
+  <mdb:metadataIdentifier>
+    <mcc:MD_Identifier>
+      <mcc:code>
+        <gco:CharacterString>9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4</gco:CharacterString>
+      </mcc:code>
+      <mcc:codeSpace>
+        <gco:CharacterString>urn:uuid</gco:CharacterString>
+      </mcc:codeSpace>
+    </mcc:MD_Identifier>
+  </mdb:metadataIdentifier>
+  <mdb:defaultLocale>
+    <lan:PT_Locale id="EN">
+      <lan:language>
+        <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
+                                 codeListValue="anyValidURI"/>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:defaultLocale>
+  <mdb:metadataScope>
+    <mdb:MD_MetadataScope>
+      <mdb:resourceScope>
+        <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                          codeListValue="dataset"/>
+      </mdb:resourceScope>
+      <mdb:name gco:nilReason="missing">
+        <gco:CharacterString/>
+      </mdb:name>
+    </mdb:MD_MetadataScope>
+  </mdb:metadataScope>
+  <mdb:contact>
+    <cit:CI_Responsibility>
+      <cit:role>
+        <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                         codeListValue="pointOfContact"/>
+      </cit:role>
+      <cit:party>
+        <cit:CI_Organisation>
+          <cit:name gco:nilReason="missing">
+            <gco:CharacterString/>
+          </cit:name>
+          <cit:contactInfo>
+            <cit:CI_Contact>
+              <cit:address>
+                <cit:CI_Address>
+                  <cit:electronicMailAddress gco:nilReason="missing">
+                    <gco:CharacterString/>
+                  </cit:electronicMailAddress>
+                </cit:CI_Address>
+              </cit:address>
+            </cit:CI_Contact>
+          </cit:contactInfo>
+          <cit:individual>
+            <cit:CI_Individual>
+              <cit:name gco:nilReason="missing">
+                <gco:CharacterString/>
+              </cit:name>
+              <cit:positionName gco:nilReason="missing">
+                <gco:CharacterString/>
+              </cit:positionName>
+            </cit:CI_Individual>
+          </cit:individual>
+        </cit:CI_Organisation>
+      </cit:party>
+    </cit:CI_Responsibility>
+  </mdb:contact>
+  <mdb:dateInfo>
+    <cit:CI_Date>
+      <cit:date>
+        <gco:DateTime>2020-08-18T08:02:41</gco:DateTime>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                             codeListValue="revision"/>
+      </cit:dateType>
+    </cit:CI_Date>
+  </mdb:dateInfo>
+  <mdb:dateInfo>
+    <cit:CI_Date>
+      <cit:date>
+        <gco:DateTime>2005-03-31T19:13:30</gco:DateTime>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+      </cit:dateType>
+    </cit:CI_Date>
+  </mdb:dateInfo>
+  <mdb:metadataStandard>
+    <cit:CI_Citation>
+      <cit:title>
+        <gco:CharacterString>ISO 19115-3</gco:CharacterString>
+      </cit:title>
+    </cit:CI_Citation>
+  </mdb:metadataStandard>
+  <mdb:metadataLinkage>
+    <cit:CI_OnlineResource>
+      <cit:linkage>
+        <gco:CharacterString>https://vanilla.geocat.net/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4</gco:CharacterString>
+      </cit:linkage>
+      <cit:function>
+        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
+                                   codeListValue="completeMetadata"/>
+      </cit:function>
+    </cit:CI_OnlineResource>
+  </mdb:metadataLinkage>
+  <mdb:referenceSystemInfo>
+    <mrs:MD_ReferenceSystem>
+      <mrs:referenceSystemIdentifier>
+        <mcc:MD_Identifier>
+          <mcc:code>
+            <gco:CharacterString>WGS 1984</gco:CharacterString>
+          </mcc:code>
+        </mcc:MD_Identifier>
+      </mrs:referenceSystemIdentifier>
+    </mrs:MD_ReferenceSystem>
+  </mdb:referenceSystemInfo>
+  <mdb:identificationInfo>
+    <mri:MD_DataIdentification>
+      <mri:citation>
+        <cit:CI_Citation>
+          <cit:title>
+            <gco:CharacterString>Template for geographical data</gco:CharacterString>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date/>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                                     codeListValue="creation"/>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+        </cit:CI_Citation>
+      </mri:citation>
+      <mri:abstract gco:nilReason="missing">
+        <gco:CharacterString/>
+      </mri:abstract>
+      <mri:purpose gco:nilReason="missing">
+        <gco:CharacterString/>
+      </mri:purpose>
+      <mri:status>
+        <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
+                             codeListValue=""/>
+      </mri:status>
+      <mri:pointOfContact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                             codeListValue="originator"/>
+          </cit:role>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name gco:nilReason="missing">
+                <gco:CharacterString/>
+              </cit:name>
+              <cit:contactInfo>
+                <cit:CI_Contact>
+                  <cit:address>
+                    <cit:CI_Address>
+                      <cit:electronicMailAddress gco:nilReason="missing">
+                        <gco:CharacterString/>
+                      </cit:electronicMailAddress>
+                    </cit:CI_Address>
+                  </cit:address>
+                </cit:CI_Contact>
+              </cit:contactInfo>
+              <cit:individual>
+                <cit:CI_Individual>
+                  <cit:name gco:nilReason="missing">
+                    <gco:CharacterString/>
+                  </cit:name>
+                  <cit:positionName gco:nilReason="missing">
+                    <gco:CharacterString/>
+                  </cit:positionName>
+                </cit:CI_Individual>
+              </cit:individual>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mri:pointOfContact>
+      <mri:spatialRepresentationType>
+        <mcc:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_SpatialRepresentationTypeCode"
+                                              codeListValue=""/>
+      </mri:spatialRepresentationType>
+      <mri:spatialResolution>
+        <mri:MD_Resolution>
+          <mri:equivalentScale>
+            <mri:MD_RepresentativeFraction>
+              <mri:denominator>
+                <gco:Integer/>
+              </mri:denominator>
+            </mri:MD_RepresentativeFraction>
+          </mri:equivalentScale>
+        </mri:MD_Resolution>
+      </mri:spatialResolution>
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>environment</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:temporalElement>
+            <gex:EX_TemporalExtent>
+              <gex:extent>
+                <gml:TimePeriod gml:id="A1234">
+                  <gml:beginPosition/>
+                  <gml:endPosition/>
+                </gml:TimePeriod>
+              </gex:extent>
+            </gex:EX_TemporalExtent>
+          </gex:temporalElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:geographicElement>
+            <gex:EX_GeographicBoundingBox>
+              <gex:westBoundLongitude>
+                <gco:Decimal>-180.00</gco:Decimal>
+              </gex:westBoundLongitude>
+              <gex:eastBoundLongitude>
+                <gco:Decimal>180.00</gco:Decimal>
+              </gex:eastBoundLongitude>
+              <gex:southBoundLatitude>
+                <gco:Decimal>-90.00</gco:Decimal>
+              </gex:southBoundLatitude>
+              <gex:northBoundLatitude>
+                <gco:Decimal>90.00</gco:Decimal>
+              </gex:northBoundLatitude>
+            </gex:EX_GeographicBoundingBox>
+          </gex:geographicElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:geographicElement>
+            <gex:EX_GeographicBoundingBox>
+              <gex:westBoundLongitude>
+                <gco:Decimal>2.00</gco:Decimal>
+              </gex:westBoundLongitude>
+              <gex:eastBoundLongitude>
+                <gco:Decimal>4.00</gco:Decimal>
+              </gex:eastBoundLongitude>
+              <gex:southBoundLatitude>
+                <gco:Decimal>1.00</gco:Decimal>
+              </gex:southBoundLatitude>
+              <gex:northBoundLatitude>
+                <gco:Decimal>2.00</gco:Decimal>
+              </gex:northBoundLatitude>
+            </gex:EX_GeographicBoundingBox>
+          </gex:geographicElement>
+          <gex:geographicElement>
+            <gex:EX_BoundingPolygon>
+              <gex:polygon>
+                <gml:MultiSurface srsName="urn:ogc:def:crs:EPSG:6.6:4326">
+                  <gml:surfaceMember>
+                    <gml:Polygon srsName="urn:ogc:def:crs:EPSG:6.6:4326">
+                      <gml:exterior>
+                        <gml:LinearRing srsName="urn:ogc:def:crs:EPSG:6.6:4326">
+                          <gml:posList srsDimension="2">19.14516819620529 6.503906249999989 1.6989411199330675 -9.90234017372131 -2.9869273933348666 -3.808586597442623 -5.790896812871949 19.62892055511473 12.382928338487403 29.941413402557377 20.028395150602293 22.441420555114753 19.14516819620529 6.503906249999989</gml:posList>
+                        </gml:LinearRing>
+                      </gml:exterior>
+                    </gml:Polygon>
+                  </gml:surfaceMember>
+                </gml:MultiSurface>
+              </gex:polygon>
+            </gex:EX_BoundingPolygon>
+          </gex:geographicElement>
+          <gex:verticalElement>
+            <gex:EX_VerticalExtent>
+              <gex:minimumValue>
+                <gco:Real/>
+              </gex:minimumValue>
+              <gex:maximumValue>
+                <gco:Real/>
+              </gex:maximumValue>
+              <gex:verticalCRS/>
+            </gex:EX_VerticalExtent>
+          </gex:verticalElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:resourceMaintenance>
+        <mmi:MD_MaintenanceInformation>
+          <mmi:maintenanceAndUpdateFrequency>
+            <mmi:MD_MaintenanceFrequencyCode codeListValue="asNeeded"
+                                             codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode"/>
+          </mmi:maintenanceAndUpdateFrequency>
+        </mmi:MD_MaintenanceInformation>
+      </mri:resourceMaintenance>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword gco:nilReason="missing">
+            <gco:CharacterString/>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeListValue="theme"
+                                    codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"/>
+          </mri:type>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword>
+            <gco:CharacterString>World</gco:CharacterString>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeListValue="place"
+                                    codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"/>
+          </mri:type>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:resourceConstraints>
+        <mco:MD_LegalConstraints>
+          <mco:accessConstraints>
+            <mco:MD_RestrictionCode codeListValue="copyright"
+                                    codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_RestrictionCode"/>
+          </mco:accessConstraints>
+          <mco:useConstraints>
+            <mco:MD_RestrictionCode codeListValue="otherRestrictions"
+                                    codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_RestrictionCode"/>
+          </mco:useConstraints>
+          <mco:otherConstraints gco:nilReason="missing">
+            <gco:CharacterString/>
+          </mco:otherConstraints>
+        </mco:MD_LegalConstraints>
+      </mri:resourceConstraints>
+      <mri:defaultLocale>
+        <lan:PT_Locale>
+          <lan:language>
+            <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
+          </lan:language>
+          <lan:characterEncoding>
+            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
+                                     codeListValue="utf8"/>
+          </lan:characterEncoding>
+        </lan:PT_Locale>
+      </mri:defaultLocale>
+      <mri:supplementalInformation gco:nilReason="missing">
+        <gco:CharacterString/>
+      </mri:supplementalInformation>
+    </mri:MD_DataIdentification>
+  </mdb:identificationInfo>
+  <mdb:contentInfo>
+    <mrc:MD_FeatureCatalogue>
+      <mrc:featureCatalogue>
+        <gfc:FC_FeatureCatalogue>
+          <gfc:producer/>
+          <gfc:featureType>
+            <gfc:FC_FeatureType>
+              <gfc:typeName>Table name</gfc:typeName>
+              <gfc:isAbstract>
+                <gco:Boolean>false</gco:Boolean>
+              </gfc:isAbstract>
+              <gfc:carrierOfCharacteristics>
+                <gfc:FC_FeatureAttribute>
+                  <gfc:memberName>Column name</gfc:memberName>
+                  <gfc:definition>
+                    <gco:CharacterString>Definition</gco:CharacterString>
+                  </gfc:definition>
+                  <gfc:cardinality/>
+                </gfc:FC_FeatureAttribute>
+              </gfc:carrierOfCharacteristics>
+              <gfc:featureCatalogue/>
+            </gfc:FC_FeatureType>
+          </gfc:featureType>
+        </gfc:FC_FeatureCatalogue>
+      </mrc:featureCatalogue>
+    </mrc:MD_FeatureCatalogue>
+  </mdb:contentInfo>
+  <mdb:distributionInfo>
+    <mrd:MD_Distribution/>
+  </mdb:distributionInfo>
+  <mdb:resourceLineage>
+    <mrl:LI_Lineage>
+      <mrl:statement gco:nilReason="missing">
+        <gco:CharacterString/>
+      </mrl:statement>
+      <mrl:scope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                              codeListValue="dataset"/>
+          </mcc:level>
+        </mcc:MD_Scope>
+      </mrl:scope>
+    </mrl:LI_Lineage>
+  </mdb:resourceLineage>
+</mdb:MD_Metadata>


### PR DESCRIPTION

Operation `GET /api/records/{metadataUuid}/extents.json` return a list of available extent.

```json
[
{
href: "http://localhost:8080/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4/extents.png",
type: "ALL",
xpath: "",
description: ""
},
{
href: "http://localhost:8080/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4/extents/1.png",
type: "EX_GeographicBoundingBox",
xpath: "/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:extent[2]/gex:EX_Extent/gex:geographicElement/gex:EX_GeographicBoundingBox",
description: "Planet earth"
},
{
href: "http://localhost:8080/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4/extents/2.png",
type: "EX_GeographicBoundingBox",
xpath: "/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:extent[3]/gex:EX_Extent/gex:geographicElement[1]/gex:EX_GeographicBoundingBox",
description: ""
},
{
href: "http://localhost:8080/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4/extents/3.png",
type: "EX_BoundingPolygon",
xpath: "/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:extent[3]/gex:EX_Extent/gex:geographicElement[2]/gex:EX_BoundingPolygon",
description: ""
},
{
href: "http://localhost:8080/geonetwork/srv/api/records/9fa0dbe1-1a0d-4fbb-86ad-e7729b9697d4/extents/4.png",
type: "EX_GeographicBoundingBox",
xpath: "/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:extent[3]/gex:EX_Extent/gex:geographicElement[3]/gex:EX_GeographicBoundingBox",
description: ""
}
]
```

Operation `GET /api/records/{metadataUuid}/extents.png` return all extents combined in one image (same as before).

Operation `GET /api/records/{metadataUuid}/extents/{extentIndex}.png` return the requested extent. The extent can be a bounding box or a bounding polygon.

This is only supported for ISO19139 and ISO19115-3 standards.

Avoid NPE for ISO19110.

