### PR TITLE
API / Extent / Formatters / XSL / Display all geometry separately

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/spatial/SpatialIndexWriter.java
@@ -206,7 +206,7 @@ public class SpatialIndexWriter implements FeatureListener {
         if (value instanceof HashMap) {
             @SuppressWarnings("rawtypes")
             HashMap map = (HashMap) value;
-            List<Polygon> geoms = new ArrayList<Polygon>();
+            List<MultiPolygon> geoms = new ArrayList<MultiPolygon>();
             for (Object entry : map.values()) {
                 addToList(geoms, entry);
             }
@@ -226,14 +226,16 @@ public class SpatialIndexWriter implements FeatureListener {
         }
     }
 
-    public static void addToList(List<Polygon> geoms, Object entry) {
+    public static void addToList(List<MultiPolygon> geoms, Object entry) {
         if (entry instanceof Polygon) {
-            geoms.add((Polygon) entry);
+            geoms.add(toMultiPolygon((Polygon) entry));
+        } else if (entry instanceof MultiPolygon) {
+            geoms.add((MultiPolygon) entry);
         } else if (entry instanceof Collection) {
             @SuppressWarnings("rawtypes")
             Collection collection = (Collection) entry;
             for (Object object : collection) {
-                geoms.add((Polygon) object);
+                geoms.add(toMultiPolygon((Polygon) object));
             }
         }
     }

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -134,7 +134,7 @@
         </xsl:for-each>
       </xsl:variable>
 
-      
+
       <xsl:choose>
         <xsl:when test="$byThesaurus">
           <xsl:for-each-group select="$tags/tag" group-by="@thesaurus">
@@ -438,7 +438,7 @@
 
 
 
-  <!-- Some major sections are boxed but 
+  <!-- Some major sections are boxed but
   * if part of fieldsWithFieldset exception
   * has content
   * only if more than one child to be displayed (non flat mode only) bypass container elements
@@ -488,10 +488,20 @@
   </xsl:template>
 
 
+  <xsl:template mode="render-field"
+                match="gex:EX_BoundingPolygon/gex:polygon"
+                priority="100">
+    <xsl:copy-of select="gn-fn-render:extent($metadataUuid,
+        count(ancestor::mri:extent/preceding-sibling::mri:extent/*/*[local-name() = 'geographicElement']/*) +
+        count(../../preceding-sibling::gex:geographicElement) + 1)"/>
+    <br/>
+    <br/>
+  </xsl:template>
+
   <!-- Display spatial extents containing bounding polygons on a map -->
 
   <xsl:template mode="render-field"
-                match="gex:EX_Extent[gex:geographicElement/*/gex:polygon]"
+                match="gex:EX_Extent"
                 priority="100">
     <div class="entry name">
     <h4>
@@ -500,21 +510,10 @@
                            select="@*"/>
     </h4>
     <div class="target">
+      <xsl:apply-templates mode="render-field"
+                           select="gex:*"/>
 
-    <xsl:apply-templates mode="render-field" select="gex:description"/>
-
-    <!-- Display all included bounding polygons/boxes on the one map -->
-
-    <xsl:copy-of select="gn-fn-render:extent($metadataUuid)"/>
-
-    <!-- Display any included geographic descriptions separately after map -->
-
-    <xsl:apply-templates mode="render-field" select="gex:geographicElement[gex:EX_GeographicDescription]"/>
-
-    <xsl:apply-templates mode="render-field" select="gex:temporalElement"/>
-    <xsl:apply-templates mode="render-field" select="gex:verticalElement"/>
-
-    </div>
+      </div>
     </div>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -471,6 +471,15 @@
     <br/>
   </xsl:template>
 
+  <xsl:template mode="render-field"
+                match="gmd:EX_BoundingPolygon/gmd:polygon">
+    <xsl:copy-of select="gn-fn-render:extent($metadataUuid,
+        count(ancestor::gmd:extent/preceding-sibling::gmd:extent/*/*[local-name() = 'geographicElement']/*) +
+        count(../../preceding-sibling::gmd:geographicElement) + 1)"/>
+    <br/>
+    <br/>
+  </xsl:template>
+
 
   <!-- Display spatial extents containing bounding polygons on a map -->
 
@@ -485,16 +494,20 @@
       </h2>
       <div class="target"><xsl:comment select="name()"/>
 
-        <xsl:apply-templates mode="render-field" select="gmd:description"/>
+        <xsl:apply-templates mode="render-field"
+                             select="gmd:description"/>
 
-        <xsl:copy-of select="gn-fn-render:extent($metadataUuid)"/>
+        <xsl:apply-templates mode="render-field"
+                             select="gmd:geographicElement[not(gmd:EX_GeographicDescription)]"/>
 
         <!-- Display any included geographic descriptions separately after displayed map -->
+        <xsl:apply-templates mode="render-field"
+                             select="gmd:geographicElement[gmd:EX_GeographicDescription]"/>
 
-        <xsl:apply-templates mode="render-field" select="gmd:geographicElement[gmd:EX_GeographicDescription]"/>
-
-        <xsl:apply-templates mode="render-field" select="gmd:temporalElement"/>
-        <xsl:apply-templates mode="render-field" select="gmd:verticalElement"/>
+        <xsl:apply-templates mode="render-field"
+                             select="gmd:temporalElement"/>
+        <xsl:apply-templates mode="render-field"
+                             select="gmd:verticalElement"/>
 
       </div>
     </div>

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MetadataExtentApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MetadataExtentApiTest.java
@@ -180,7 +180,25 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataTwoExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/2.png", uuid))
+        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
+            .session(mockHttpSession)
+            .accept(MediaType.IMAGE_PNG_VALUE))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
+            .andReturn().getResponse().getContentAsByteArray();
+        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+
+        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/1.png", uuid))
+            .session(mockHttpSession)
+            .accept(MediaType.IMAGE_PNG_VALUE))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
+            .andReturn().getResponse().getContentAsByteArray();
+        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-1");
+
+        assertEquals("70e4652a68e5ab8ae8803a0437958bdc", DigestUtils.md5DigestAsHex(reponseBuffer));
+
+        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/2.png", uuid))
             .session(mockHttpSession)
             .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
@@ -208,7 +226,15 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataThreeExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/4.png", uuid))
+        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
+            .session(mockHttpSession)
+            .accept(MediaType.IMAGE_PNG_VALUE))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
+            .andReturn().getResponse().getContentAsByteArray();
+        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+
+        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/4.png", uuid))
             .session(mockHttpSession)
             .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
@@ -216,7 +242,7 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
             .andReturn().getResponse().getContentAsByteArray();
 
         saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
-        assertEquals("3f40d26c831050e3bf75b90ba803b4e6", DigestUtils.md5DigestAsHex(reponseBuffer));
+        assertEquals("d9f31e3de583ff135160568dab225589", DigestUtils.md5DigestAsHex(reponseBuffer));
     }
 
     @Test
@@ -225,7 +251,15 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataIso191153ThreeExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png", uuid))
+        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
+            .session(mockHttpSession)
+            .accept(MediaType.IMAGE_PNG_VALUE))
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
+            .andReturn().getResponse().getContentAsByteArray();
+        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+
+        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png", uuid))
             .session(mockHttpSession)
             .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
@@ -233,7 +267,7 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
             .andReturn().getResponse().getContentAsByteArray();
 
         saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
-        assertEquals("ea89d29e84cb3f1f7f1102ffda06708b", DigestUtils.md5DigestAsHex(reponseBuffer));
+        assertEquals("6fc67bf08a6ee8c06dfbfe448172c060", DigestUtils.md5DigestAsHex(reponseBuffer));
     }
 
     @Test

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -86,6 +86,16 @@
            alt="{$schemaStrings/thumbnail}"
            src="{$nodeUrl}api/records/{$uuid}/extents.png"/>
     </xsl:if>
+  </xsl:function>
+
+  <xsl:function name="gn-fn-render:extent">
+    <xsl:param name="uuid" as="xs:string"/>
+    <xsl:param name="index" as="xs:integer"/>
+    <xsl:if test="$uuid">
+      <img class="gn-img-extent"
+           alt="{$schemaStrings/thumbnail}"
+           src="{$nodeUrl}api/records/{$uuid}/extents/{$index}.png"/>
+    </xsl:if>
 
   </xsl:function>
 


### PR DESCRIPTION
Done for ISO19139 and ISO19115-3

![image](https://user-images.githubusercontent.com/1701393/91418352-4fae3280-e852-11ea-80c8-78e8d9dc4455.png)


BTW we have coordinate inverted for polygon. This only happens when rendering one geometry. extents.png works fine.

Add support for MultiSurface which is the default encoding on OL map.